### PR TITLE
Allscreen preview

### DIFF
--- a/Controls.xaml
+++ b/Controls.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WPF_WallpaperCrop_v2"
         mc:Ignorable="d"
-        Title="Controls" Height="350" Width="525" Loaded="Window_Loaded" Closing="Window_Closing">
+        Title="Controls" Height="350" Width="525" Loaded="Window_Loaded" Closing="Window_Closing" Deactivated="Window_Deactivated">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="40"/>

--- a/Controls.xaml
+++ b/Controls.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WPF_WallpaperCrop_v2"
         mc:Ignorable="d"
-        Title="Controls" Height="350" Width="525" Loaded="Window_Loaded" Closing="Window_Closing" Deactivated="Window_Deactivated">
+        Title="Controls" Height="350" Width="525" Loaded="Window_Loaded" Closing="Window_Closing" Deactivated="Window_Deactivated" SizeToContent="Height">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="40"/>

--- a/Controls.xaml
+++ b/Controls.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WPF_WallpaperCrop_v2"
         mc:Ignorable="d"
-        Title="Controls" Height="350" Width="525" Loaded="Window_Loaded" Closing="Window_Closing" Deactivated="Window_Deactivated" SizeToContent="Height">
+        Title="Controls" Height="350" Width="525" Loaded="Window_Loaded" Closing="Window_Closing" Deactivated="Window_Deactivated" SizeToContent="Height" KeyDown="Window_KeyDown" KeyUp="Window_KeyUp">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="40"/>

--- a/Controls.xaml.cs
+++ b/Controls.xaml.cs
@@ -67,7 +67,7 @@ namespace WPF_WallpaperCrop_v2
             Topmost = true;
         }
 
-        private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        public void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
             if (e.Key == Key.Q)
             {
@@ -80,7 +80,7 @@ namespace WPF_WallpaperCrop_v2
             }
         }
 
-        private void Window_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        public void Window_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
         {
             if (e.Key == Key.Q)
             {

--- a/Controls.xaml.cs
+++ b/Controls.xaml.cs
@@ -67,6 +67,28 @@ namespace WPF_WallpaperCrop_v2
             Topmost = true;
         }
 
+        private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == Key.Q)
+            {
+                Hide();
+            }
+
+            if (e.Key == Key.Escape)
+            {
+                Close();
+            }
+        }
+
+        private void Window_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == Key.Q)
+            {
+                Show();
+                Topmost = true;
+            }
+        }
+
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             preview.Close();

--- a/Controls.xaml.cs
+++ b/Controls.xaml.cs
@@ -36,10 +36,12 @@ namespace WPF_WallpaperCrop_v2
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            orientOnRightmostScreen();
+            orientOnScreen(Side.Right);
         }
 
-        private void orientOnRightmostScreen()
+        enum Side { Left, Right };
+        bool onRightmostScreen;
+        private void orientOnScreen(Side which)
         {
             int X_MARGIN = 300; // Margin in pixels between right side of the screen and right side of this
             int Y_MARGIN = 200;
@@ -47,15 +49,25 @@ namespace WPF_WallpaperCrop_v2
             Screen[] sc = Screen.AllScreens;
             int nScreens = sc.Length;
 
-            // Show this window on the rightmost screen
+            // Show this window on the given screen
             if (nScreens > 1)
             {
-                Screen rightmostScreen = sc[nScreens - 1];
-                System.Drawing.Rectangle bounds = rightmostScreen.Bounds;
+                Screen screen;
+                if(which == Side.Left)
+                {
+                    screen = sc[1]; // TODO: Generalize for all monitor setups by using virtual screen
+                    onRightmostScreen = false;
+                } else
+                {
+                    screen = sc[nScreens - 1];
+                    onRightmostScreen = true;
+                }
+
+                System.Drawing.Rectangle bounds = screen.Bounds;
                 this.Left = bounds.Right - this.Width - X_MARGIN;
                 this.Top = bounds.Bottom - this.Height - Y_MARGIN;
-                //this.Left = rightmostScreen.Bounds.Left;
-                //this.Top = rightmostScreen.Bounds.Top;
+                //this.Left = screen.Bounds.Left;
+                //this.Top = screen.Bounds.Top;
             }
 
             //// Maximize window
@@ -78,6 +90,11 @@ namespace WPF_WallpaperCrop_v2
             {
                 Close();
             }
+
+            if (e.Key == Key.Tab)
+            {
+                switchMonitors();
+            }
         }
 
         public void Window_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
@@ -92,6 +109,21 @@ namespace WPF_WallpaperCrop_v2
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             preview.Close();
+        }
+
+        private void switchMonitors()
+        {
+
+            if (onRightmostScreen)
+            {
+                // swap to left screen
+                orientOnScreen(Side.Left);
+            }
+            else
+            {
+                // swap to right screen
+                orientOnScreen(Side.Right);
+            }
         }
 
         ///////////////////////////////// Control functionality stuff //////////////////////////////////////////

--- a/Controls.xaml.cs
+++ b/Controls.xaml.cs
@@ -32,6 +32,8 @@ namespace WPF_WallpaperCrop_v2
             preview.Show();
         }
 
+        ////////////////////////// Window Stuff ///////////////////////////////
+
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
             maximizeOnRightmostScreen();
@@ -52,6 +54,11 @@ namespace WPF_WallpaperCrop_v2
 
             // Maximize window
             this.WindowState = WindowState.Maximized; // If I remember correctly maximizeOnRightmostScreen() must be called after window load for this to work.
+        }
+
+        private void Window_Deactivated(object sender, EventArgs e)
+        {
+            Topmost = true;
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)

--- a/Controls.xaml.cs
+++ b/Controls.xaml.cs
@@ -36,11 +36,14 @@ namespace WPF_WallpaperCrop_v2
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            maximizeOnRightmostScreen();
+            orientOnRightmostScreen();
         }
 
-        private void maximizeOnRightmostScreen()
+        private void orientOnRightmostScreen()
         {
+            int X_MARGIN = 300; // Margin in pixels between right side of the screen and right side of this
+            int Y_MARGIN = 200;
+
             Screen[] sc = Screen.AllScreens;
             int nScreens = sc.Length;
 
@@ -48,12 +51,15 @@ namespace WPF_WallpaperCrop_v2
             if (nScreens > 1)
             {
                 Screen rightmostScreen = sc[nScreens - 1];
-                this.Left = rightmostScreen.Bounds.Left;
-                this.Top = rightmostScreen.Bounds.Top;
+                System.Drawing.Rectangle bounds = rightmostScreen.Bounds;
+                this.Left = bounds.Right - this.Width - X_MARGIN;
+                this.Top = bounds.Bottom - this.Height - Y_MARGIN;
+                //this.Left = rightmostScreen.Bounds.Left;
+                //this.Top = rightmostScreen.Bounds.Top;
             }
 
-            // Maximize window
-            this.WindowState = WindowState.Maximized; // If I remember correctly maximizeOnRightmostScreen() must be called after window load for this to work.
+            //// Maximize window
+            //this.WindowState = WindowState.Maximized; // If I remember correctly maximizeOnRightmostScreen() must be called after window load for this to work.
         }
 
         private void Window_Deactivated(object sender, EventArgs e)

--- a/Preview.xaml
+++ b/Preview.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WPF_WallpaperCrop_v2"
         mc:Ignorable="d"
-        Title="Preview" Height="300" Width="300" Loaded="Window_Loaded" KeyDown="Window_KeyDown">
+        Title="Preview" Height="300" Width="300" Loaded="Window_Loaded" KeyDown="Window_KeyDown" KeyUp="Window_KeyUp">
     <Grid>
         <Rectangle Fill="Black" />
         <Canvas HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/Preview.xaml.cs
+++ b/Preview.xaml.cs
@@ -47,7 +47,6 @@ namespace WPF_WallpaperCrop_v2
         /* Sets up window frame with no borders and sets it to span
          * all screens.
          * Usage: Must be called before window is loaded in order to turn borders off. */
-        // TODO: Make it work for different monitor configurations, perhaps with dialog box asking about monitor order
         private void configureWindow()
         {
             //int nMonitors = System.Windows.Forms.SystemInformation.MonitorCount;

--- a/Preview.xaml.cs
+++ b/Preview.xaml.cs
@@ -36,14 +36,6 @@ namespace WPF_WallpaperCrop_v2
             configureDragging();
         }
 
-        private void Window_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Escape)
-            {
-                controls.Close();
-            }
-        }
-
         /* Sets up window frame with no borders and sets it to span
          * all screens.
          * Usage: Must be called before window is loaded in order to turn borders off. */
@@ -56,9 +48,31 @@ namespace WPF_WallpaperCrop_v2
 
             // span monitors
             this.Left = -1920;
-            this.Width = SystemParameters.VirtualScreenWidth;
+            this.Width = SystemParameters.VirtualScreenWidth;// * 2 / 3.0;
             this.Top = 0;
             this.Height = SystemParameters.VirtualScreenHeight;
+        }
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Q)
+            {
+                controls.Hide();
+            }
+
+            if (e.Key == Key.Escape)
+            {
+                controls.Close();
+            }
+        }
+
+        private void Window_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Q)
+            {
+                controls.Show();
+                controls.Topmost = true;
+            }
         }
 
 

--- a/Preview.xaml.cs
+++ b/Preview.xaml.cs
@@ -55,24 +55,12 @@ namespace WPF_WallpaperCrop_v2
 
         private void Window_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Q)
-            {
-                controls.Hide();
-            }
-
-            if (e.Key == Key.Escape)
-            {
-                controls.Close();
-            }
+            controls.Window_KeyDown(sender, e);
         }
 
         private void Window_KeyUp(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Q)
-            {
-                controls.Show();
-                controls.Topmost = true;
-            }
+            controls.Window_KeyUp(sender, e);
         }
 
 

--- a/Preview.xaml.cs
+++ b/Preview.xaml.cs
@@ -45,22 +45,21 @@ namespace WPF_WallpaperCrop_v2
         }
 
         /* Sets up window frame with no borders and sets it to span
-         * the left two screens: all except the rightmost one, where the controls are.
+         * all screens.
          * Usage: Must be called before window is loaded in order to turn borders off. */
         // TODO: Make it work for different monitor configurations, perhaps with dialog box asking about monitor order
         private void configureWindow()
         {
-            int nMonitors = System.Windows.Forms.SystemInformation.MonitorCount;
-            Debug.Assert(nMonitors > 1);
+            //int nMonitors = System.Windows.Forms.SystemInformation.MonitorCount;
 
             this.WindowStyle = WindowStyle.None; // Gets rid of top bar
             this.AllowsTransparency = true; // Gets rid of window-resize borders
 
-            // span left two monitors
+            // span monitors
             this.Left = -1920;
-            this.Width = System.Windows.SystemParameters.VirtualScreenWidth * 2 / 3;
+            this.Width = SystemParameters.VirtualScreenWidth;
             this.Top = 0;
-            this.Height = System.Windows.SystemParameters.VirtualScreenHeight;
+            this.Height = SystemParameters.VirtualScreenHeight;
         }
 
 


### PR DESCRIPTION
Now preview window spans across all monitors. To accommodate, the control window is much smaller and easily hideable and moveable across screens using the Q and Tab keys respectively.
