### PR TITLE
Export wallpaper

### DIFF
--- a/Controls.xaml
+++ b/Controls.xaml
@@ -12,11 +12,11 @@
             <RowDefinition/>
         </Grid.RowDefinitions>
         <Rectangle Grid.Row="0" Fill="Black" />
-        <Button x:Name="button" Grid.Row="0" Content="Import Image..." HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="120" Click="chooseImage"/>
+        <Button x:Name="button" Grid.Row="0" Content="Import Image..." HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="120" Click="importImage"/>
         <Button x:Name="button1" Grid.Row="0" Content="Re-center" HorizontalAlignment="Center" Margin="0,10,0,0" VerticalAlignment="Top" Width="75" Click="centerImage"/>
         <Rectangle Grid.Row="1" Fill="Black" />
         <Image x:Name="image" Grid.Row="1" Canvas.Left="0" Canvas.Top="0" Source="111111.jpg" SnapsToDevicePixels="True"/>
-        <Button x:Name="button2" Content="Export Wallpaper..." HorizontalAlignment="Right" Margin="0,10,13,0" VerticalAlignment="Top" Width="120"/>
+        <Button x:Name="button2" Content="Export Wallpaper..." HorizontalAlignment="Right" Margin="0,10,13,0" VerticalAlignment="Top" Width="120" Click="exportWallpaper"/>
 
     </Grid>
 </Window>

--- a/Controls.xaml
+++ b/Controls.xaml
@@ -12,10 +12,11 @@
             <RowDefinition/>
         </Grid.RowDefinitions>
         <Rectangle Grid.Row="0" Fill="Black" />
-        <Button x:Name="button" Grid.Row="0" Content="Import Image..." HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="100" Click="chooseImage"/>
+        <Button x:Name="button" Grid.Row="0" Content="Import Image..." HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="120" Click="chooseImage"/>
         <Button x:Name="button1" Grid.Row="0" Content="Re-center" HorizontalAlignment="Center" Margin="0,10,0,0" VerticalAlignment="Top" Width="75" Click="centerImage"/>
         <Rectangle Grid.Row="1" Fill="Black" />
         <Image x:Name="image" Grid.Row="1" Canvas.Left="0" Canvas.Top="0" Source="111111.jpg" SnapsToDevicePixels="True"/>
+        <Button x:Name="button2" Content="Export Wallpaper..." HorizontalAlignment="Right" Margin="0,10,13,0" VerticalAlignment="Top" Width="120"/>
 
     </Grid>
 </Window>

--- a/Controls.xaml
+++ b/Controls.xaml
@@ -12,7 +12,7 @@
             <RowDefinition/>
         </Grid.RowDefinitions>
         <Rectangle Grid.Row="0" Fill="Black" />
-        <Button x:Name="button" Grid.Row="0" Content="Choose Image..." HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="100" Click="chooseImage"/>
+        <Button x:Name="button" Grid.Row="0" Content="Import Image..." HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="100" Click="chooseImage"/>
         <Button x:Name="button1" Grid.Row="0" Content="Re-center" HorizontalAlignment="Center" Margin="0,10,0,0" VerticalAlignment="Top" Width="75" Click="centerImage"/>
         <Rectangle Grid.Row="1" Fill="Black" />
         <Image x:Name="image" Grid.Row="1" Canvas.Left="0" Canvas.Top="0" Source="111111.jpg" SnapsToDevicePixels="True"/>

--- a/Controls.xaml.cs
+++ b/Controls.xaml.cs
@@ -148,8 +148,16 @@ namespace WPF_WallpaperCrop_v2
             wallpaperSaver.Filter = "PNG|*.png";
             if (wallpaperSaver.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
+                // Crop image
+                Int32Rect cropRect = preview.getCropRect();
+                CroppedBitmap cropped = new CroppedBitmap((BitmapSource)image.Source, cropRect);
+
+                // Save image
                 string path = wallpaperSaver.FileName;
-                // TODO: export cropped/bordered image to file
+                var encoder = new PngBitmapEncoder();
+                encoder.Frames.Add(BitmapFrame.Create(cropped));
+                using (FileStream stream = new FileStream(path, FileMode.Create))
+                    encoder.Save(stream);
             }
         }
 

--- a/Controls.xaml.cs
+++ b/Controls.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using System.IO;
 
 namespace WPF_WallpaperCrop_v2
 {
@@ -128,16 +129,27 @@ namespace WPF_WallpaperCrop_v2
 
         ///////////////////////////////// Control functionality stuff //////////////////////////////////////////
 
-        private void chooseImage(object sender, RoutedEventArgs e)
+        private void importImage(object sender, RoutedEventArgs e)
         {
-            OpenFileDialog chooseImage = new OpenFileDialog();
-            chooseImage.Title = "Choose Image";
-            chooseImage.Filter = "JPG|*.jpg|PNG|*.png";
-            if (chooseImage.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            OpenFileDialog imageChooser = new OpenFileDialog();
+            imageChooser.Title = "Choose Image";
+            imageChooser.Filter = "JPG|*.jpg|PNG|*.png";
+            if (imageChooser.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
-                BitmapImage bitmapimage = new BitmapImage(new Uri(chooseImage.SafeFileName, UriKind.Relative));
+                BitmapImage bitmapimage = new BitmapImage(new Uri(imageChooser.SafeFileName, UriKind.Relative));
                 image.Source = bitmapimage;
                 preview.setImage(bitmapimage);
+            }
+        }
+
+        private void exportWallpaper(object sender, RoutedEventArgs e)
+        {
+            SaveFileDialog wallpaperSaver = new SaveFileDialog();
+            wallpaperSaver.Filter = "PNG|*.png";
+            if (wallpaperSaver.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                string path = wallpaperSaver.FileName;
+                // TODO: export cropped/bordered image to file
             }
         }
 

--- a/Preview.xaml.cs
+++ b/Preview.xaml.cs
@@ -118,5 +118,16 @@ namespace WPF_WallpaperCrop_v2
             Canvas.SetLeft(image, -image.Width / 2);
             Canvas.SetTop(image, -image.Height / 2);
         }
+
+        internal Int32Rect getCropRect()
+        {
+            // Assumes canvas is based at the center of the screen and the focus of the canvas is its center
+            Int32Rect r = new Int32Rect();
+            r.X = -5760 / 2 - (int)Canvas.GetLeft(image);
+            r.Y = -1080 / 2 - (int)Canvas.GetTop(image);
+            r.Width = 5760;
+            r.Height = 1080;
+            return r;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This application currently only runs well on triple-monitor setups of three scre
 ## Functionality so far
 -Controls window to manipulate the image; Preview window to view full-size image
 
--Choose image using the Choose Image... button
+-Select an image using the Import Image... button
 
 -Pan around image by clicking/dragging the image in the preview window
 
@@ -25,6 +25,8 @@ This application currently only runs well on triple-monitor setups of three scre
 -Temporarily hide the controls window by holding down 'Q'.
 
 -Move the controls window to the opposite screen by pressing Tab.
+
+-When you're satisfied with the preview, click Export wallpaper... to save a png of the new image.
 
 -Press Esc to close the application.
 


### PR DESCRIPTION
Functionality to export (save) the edited image as new png image. Saves only as PNG for best quality - PNG is lossless and Windows additionally autocompresses non-PNG wallpapers before displaying them.
